### PR TITLE
Using {stringi} for pattern matching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
  checkmate,
  data.table,
  stats,
+ stringi,
  utils
 Suggests:
  covr,

--- a/R/comorbidity-package.R
+++ b/R/comorbidity-package.R
@@ -14,4 +14,4 @@ NULL
 .datatable.aware <- TRUE
 
 # Quiets concerns of R CMD check re: variable names used internally
-if (getRversion() >= "2.15.1") utils::globalVariables(c(".", "L1", ":=", "value", "canc", "diab", "diabc", "diabunc", "diabwc", "hypc", "hypunc", "metacanc", "mld", "msld", "solidtum"))
+if (getRversion() >= "2.15.1") utils::globalVariables(c(":=", "..mv", "NA", "canc", "diab", "diabc", "diabunc", "diabwc", "hypc", "hypunc", "metacanc", "mld", "msld", "solidtum", "value"))

--- a/R/comorbidity.R
+++ b/R/comorbidity.R
@@ -110,21 +110,7 @@
 #' comorbidity(x = x, id = "id", code = "code", map = "elixhauser_icd10_quan", assign0 = FALSE)
 #' @export
 
-comorbidity <- function(x, id, code, map, assign0, labelled = TRUE, tidy.codes = TRUE, stringi = TRUE) {
-
-  # set.seed(1)
-  # x <- data.frame(
-  #   id = sample(seq(1e3), size = 1e5, replace = TRUE),
-  #   code = sample_diag(1e5),
-  #   stringsAsFactors = FALSE
-  # )
-  # id = "id"
-  # code = "code"
-  # map = "charlson_icd10_quan"
-  # assign0 = FALSE
-  # labelled = TRUE
-  # tidy.codes = TRUE
-  # stringi = TRUE
+comorbidity <- function(x, id, code, map, assign0, labelled = TRUE, tidy.codes = TRUE, new = FALSE) {
 
   ### Check arguments
   arg_checks <- checkmate::makeAssertCollection()
@@ -161,7 +147,7 @@ comorbidity <- function(x, id, code, map, assign0, labelled = TRUE, tidy.codes =
   if (!arg_checks$isEmpty()) checkmate::reportAssertions(arg_checks)
 
   ### Tidy codes if required
-  if (tidy.codes) x <- .tidy(x = x, code = code, stringi = stringi)
+  if (tidy.codes) x <- .tidy(x = x, code = code, new = new)
 
   ### Create regex from a list of codes
   regex <- lapply(X = .maps[[map]], FUN = .codes_to_regex)
@@ -178,8 +164,9 @@ comorbidity <- function(x, id, code, map, assign0, labelled = TRUE, tidy.codes =
   data.table::setDT(x)
 
   ### Get list of unique codes used in dataset that match comorbidities
-  if (stringi) {
-    loc <- sapply(X = regex, FUN = function(p) stringi::stri_subset_regex(str = unique(x[[code]]), pattern = p))
+  if (new) {
+    ..cd <- unique(x[[code]])
+    loc <- sapply(X = regex, FUN = function(p) stringi::stri_subset_regex(str = ..cd, pattern = p))
   } else {
     loc <- sapply(X = regex, FUN = function(p) grep(pattern = p, x = unique(x[[code]]), value = TRUE))
   }

--- a/R/comorbidity.R
+++ b/R/comorbidity.R
@@ -27,7 +27,6 @@
 #' @param tidy.codes Tidy diagnostic codes?
 #' If `TRUE`, all codes are converted to upper case and all non-alphanumeric characters are removed using the regular expression \code{[^[:alnum:]]}.
 #' Defaults to `TRUE`.
-#' @param stringi For testing purposes only.
 #'
 #' @return A data frame with `id`, columns relative to each comorbidity domain, comorbidity score, weighted comorbidity score, and categorisations of such scores, with one row per individual.
 #'
@@ -110,7 +109,7 @@
 #' comorbidity(x = x, id = "id", code = "code", map = "elixhauser_icd10_quan", assign0 = FALSE)
 #' @export
 
-comorbidity <- function(x, id, code, map, assign0, labelled = TRUE, tidy.codes = TRUE, new = FALSE) {
+comorbidity <- function(x, id, code, map, assign0, labelled = TRUE, tidy.codes = TRUE) {
 
   ### Check arguments
   arg_checks <- checkmate::makeAssertCollection()
@@ -147,7 +146,7 @@ comorbidity <- function(x, id, code, map, assign0, labelled = TRUE, tidy.codes =
   if (!arg_checks$isEmpty()) checkmate::reportAssertions(arg_checks)
 
   ### Tidy codes if required
-  if (tidy.codes) x <- .tidy(x = x, code = code, new = new)
+  if (tidy.codes) x <- .tidy(x = x, code = code)
 
   ### Create regex from a list of codes
   regex <- lapply(X = .maps[[map]], FUN = .codes_to_regex)
@@ -164,12 +163,8 @@ comorbidity <- function(x, id, code, map, assign0, labelled = TRUE, tidy.codes =
   data.table::setDT(x)
 
   ### Get list of unique codes used in dataset that match comorbidities
-  if (new) {
-    ..cd <- unique(x[[code]])
-    loc <- sapply(X = regex, FUN = function(p) stringi::stri_subset_regex(str = ..cd, pattern = p))
-  } else {
-    loc <- sapply(X = regex, FUN = function(p) grep(pattern = p, x = unique(x[[code]]), value = TRUE))
-  }
+  ..cd <- unique(x[[code]])
+  loc <- sapply(X = regex, FUN = function(p) stringi::stri_subset_regex(str = ..cd, pattern = p))
   loc <- utils::stack(loc)
   data.table::setDT(loc)
   data.table::setnames(x = loc, new = c(code, "ind"))

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -1,17 +1,9 @@
 #' @keywords internal
-.tidy <- function(x, code, new = FALSE) {
-  if (new) {
-    ### Upper case all codes
-    x[[code]] <- stringi::stri_trans_toupper(x[[code]])
-    ### Remove non-alphanumeric characters
-    x[[code]] <- stringi::stri_replace_all_charclass(str = x[[code]], pattern = "[^a-zA-Z0-9]", replacement = "")
-  } else {
-    ### Upper case all codes
-    x[[code]] <- toupper(x[[code]])
-    ### Remove non-alphanumeric characters
-    x[[code]] <- gsub(pattern = "[^[:alnum:]]", x = x[[code]], replacement = "")
-  }
-
+.tidy <- function(x, code) {
+  ### Upper case all codes
+  x[[code]] <- stringi::stri_trans_toupper(x[[code]])
+  ### Remove non-alphanumeric characters
+  x[[code]] <- stringi::stri_replace_all_charclass(str = x[[code]], pattern = "[^a-zA-Z0-9]", replacement = "")
   ### Return x
   return(x)
 }

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -1,10 +1,16 @@
 #' @keywords internal
-.tidy <- function(x, code) {
-  ### Upper case all codes
-  x[[code]] <- toupper(x[[code]])
-
-  ### Remove non-alphanumeric characters
-  x[[code]] <- gsub(pattern = "[^[:alnum:]]", x = x[[code]], replacement = "")
+.tidy <- function(x, code, stringi = FALSE) {
+  if (stringi) {
+    ### Upper case all codes
+    x[[code]] <- stringi::stri_trans_toupper(x[[code]])
+    ### Remove non-alphanumeric characters
+    x[[code]] <- stringi::stri_replace_all_charclass(str = x[[code]], pattern = "[^a-zA-Z0-9]", replacement = "")
+  } else {
+    ### Upper case all codes
+    x[[code]] <- toupper(x[[code]])
+    ### Remove non-alphanumeric characters
+    x[[code]] <- gsub(pattern = "[^[:alnum:]]", x = x[[code]], replacement = "")
+  }
 
   ### Return x
   return(x)

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -1,6 +1,6 @@
 #' @keywords internal
-.tidy <- function(x, code, stringi = FALSE) {
-  if (stringi) {
+.tidy <- function(x, code, new = FALSE) {
+  if (new) {
     ### Upper case all codes
     x[[code]] <- stringi::stri_trans_toupper(x[[code]])
     ### Remove non-alphanumeric characters

--- a/man/comorbidity.Rd
+++ b/man/comorbidity.Rd
@@ -4,7 +4,16 @@
 \alias{comorbidity}
 \title{Comorbidity mapping.}
 \usage{
-comorbidity(x, id, code, map, assign0, labelled = TRUE, tidy.codes = TRUE)
+comorbidity(
+  x,
+  id,
+  code,
+  map,
+  assign0,
+  labelled = TRUE,
+  tidy.codes = TRUE,
+  stringi = FALSE
+)
 }
 \arguments{
 \item{x}{A tidy \code{data.frame} (or a \code{data.table}; \code{tibble}s are supported too) with one column containing an individual ID and a column containing all diagnostic codes.
@@ -39,6 +48,8 @@ Defaults to \code{TRUE}.}
 \item{tidy.codes}{Tidy diagnostic codes?
 If \code{TRUE}, all codes are converted to upper case and all non-alphanumeric characters are removed using the regular expression \code{[^[:alnum:]]}.
 Defaults to \code{TRUE}.}
+
+\item{stringi}{For testing purposes only.}
 }
 \value{
 A data frame with \code{id}, columns relative to each comorbidity domain, comorbidity score, weighted comorbidity score, and categorisations of such scores, with one row per individual.

--- a/man/comorbidity.Rd
+++ b/man/comorbidity.Rd
@@ -4,16 +4,7 @@
 \alias{comorbidity}
 \title{Comorbidity mapping.}
 \usage{
-comorbidity(
-  x,
-  id,
-  code,
-  map,
-  assign0,
-  labelled = TRUE,
-  tidy.codes = TRUE,
-  stringi = TRUE
-)
+comorbidity(x, id, code, map, assign0, labelled = TRUE, tidy.codes = TRUE)
 }
 \arguments{
 \item{x}{A tidy \code{data.frame} (or a \code{data.table}; \code{tibble}s are supported too) with one column containing an individual ID and a column containing all diagnostic codes.
@@ -48,8 +39,6 @@ Defaults to \code{TRUE}.}
 \item{tidy.codes}{Tidy diagnostic codes?
 If \code{TRUE}, all codes are converted to upper case and all non-alphanumeric characters are removed using the regular expression \code{[^[:alnum:]]}.
 Defaults to \code{TRUE}.}
-
-\item{stringi}{For testing purposes only.}
 }
 \value{
 A data frame with \code{id}, columns relative to each comorbidity domain, comorbidity score, weighted comorbidity score, and categorisations of such scores, with one row per individual.

--- a/man/comorbidity.Rd
+++ b/man/comorbidity.Rd
@@ -12,7 +12,7 @@ comorbidity(
   assign0,
   labelled = TRUE,
   tidy.codes = TRUE,
-  stringi = FALSE
+  stringi = TRUE
 )
 }
 \arguments{

--- a/testing.R
+++ b/testing.R
@@ -1,24 +1,30 @@
-reprex::reprex({
-  library(comorbidity)
-  library(bench)
-  library(ggplot2)
-  library(ggbeeswarm)
-  library(tidyr)
+library(comorbidity)
+library(ggplot2)
+library(ggbeeswarm)
+library(tidyr)
 
-  set.seed(1)
-  x <- data.frame(
-    id = sample(seq(1e3), size = 1e5, replace = TRUE),
-    code = sample_diag(1e5),
-    stringsAsFactors = FALSE
-  )
+set.seed(1)
+x <- data.frame(
+  id = sample(seq(1e5), size = 1e7, replace = TRUE),
+  code = sample_diag(1e7),
+  stringsAsFactors = FALSE
+)
 
-  addd <- sample(x = seq(nrow(x)), size = 5e3)
-  x$code[addd] <- paste0(".", x$code[addd])
+addd <- sample(x = seq(nrow(x)), size = 5e4)
+x$code[addd] <- paste0(".", x$code[addd])
 
-  bm <- bench::mark(
-    "current" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, stringi = FALSE),
-    "stringi" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, stringi = TRUE),
-    iterations = 30
-  )
-  bm
-}, venue = "gh")
+#
+id <- "id"
+code <- "code"
+map <- "elixhauser_icd10_quan"
+assign0 <- FALSE
+labelled <- FALSE
+tidy.codes <- TRUE
+
+bm <- bench::mark(
+  "new" = comorbidity(x = x, id = id, code = code, map = map, assign0 = assign0, labelled = labelled, tidy.codes = tidy.codes, new = TRUE),
+  "old" = comorbidity(x = x, id = id, code = code, map = map, assign0 = assign0, labelled = labelled, tidy.codes = tidy.codes, new = FALSE),
+  iterations = 30
+)
+bm
+autoplot(bm)

--- a/testing.R
+++ b/testing.R
@@ -1,21 +1,24 @@
-devtools::load_all()
-library(bench)
-library(ggplot2)
-library(ggbeeswarm)
+reprex::reprex({
+  library(comorbidity)
+  library(bench)
+  library(ggplot2)
+  library(ggbeeswarm)
+  library(tidyr)
 
-set.seed(1)
-x <- data.frame(
-  id = sample(seq(3e4), size = 3e6, replace = TRUE),
-  code = sample_diag(3e6),
-  stringsAsFactors = FALSE
-)
+  set.seed(1)
+  x <- data.frame(
+    id = sample(seq(1e3), size = 1e5, replace = TRUE),
+    code = sample_diag(1e5),
+    stringsAsFactors = FALSE
+  )
 
-addd <- sample(x = seq(nrow(x)), size = 3e4)
-x$code[addd] <- paste0(".", x$code[addd])
+  addd <- sample(x = seq(nrow(x)), size = 5e3)
+  x$code[addd] <- paste0(".", x$code[addd])
 
-bm <- bench::mark(
-  "current" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, tidy.codes = TRUE),
-  "stringi" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, stringi = TRUE, tidy.codes = TRUE),
-  iterations = 20
-)
-autoplot(bm)
+  bm <- bench::mark(
+    "current" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, stringi = FALSE),
+    "stringi" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, stringi = TRUE),
+    iterations = 30
+  )
+  bm
+}, venue = "gh")

--- a/testing.R
+++ b/testing.R
@@ -5,34 +5,17 @@ library(ggbeeswarm)
 
 set.seed(1)
 x <- data.frame(
-  id = sample(seq(1e4), size = 1e6, replace = TRUE),
-  code = sample_diag(1e6),
+  id = sample(seq(3e4), size = 3e6, replace = TRUE),
+  code = sample_diag(3e6),
   stringsAsFactors = FALSE
 )
-id <- "id"
-code <- "code"
-map <- "charlson_icd10_quan"
-assign0 <- FALSE
-labelled <- TRUE
-tidy.codes <- TRUE
-regex <- lapply(X = .maps[[map]], FUN = .codes_to_regex)
 
-xa <- x[[code]]
-addd <- sample(x = seq(length(xa)), size = 1000)
-xa[addd] <- paste0(".", xa[addd])
+addd <- sample(x = seq(nrow(x)), size = 3e4)
+x$code[addd] <- paste0(".", x$code[addd])
 
 bm <- bench::mark(
-  ".tidy" = .tidy(x = x, code = code),
-  ".tidy2" = .tidy2(x = x, code = code),
-  iterations = 20,
-  relative = TRUE
-)
-autoplot(bm)
-
-bm <- bench::mark(
-  "grep" = grep(pattern = regex[[2]], x = x$code, value = TRUE),
-  "stri_subset_regex" = stringi::stri_subset_regex(str = x$code, pattern = regex[[2]]),
-  iterations = 20,
-  relative = TRUE
+  "current" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, tidy.codes = TRUE),
+  "stringi" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, stringi = TRUE, tidy.codes = TRUE),
+  iterations = 20
 )
 autoplot(bm)

--- a/testing.R
+++ b/testing.R
@@ -1,7 +1,5 @@
-library(comorbidity)
-library(ggplot2)
-library(ggbeeswarm)
-library(tidyr)
+devtools::load_all()
+library(profvis)
 
 set.seed(1)
 x <- data.frame(
@@ -21,10 +19,6 @@ assign0 <- FALSE
 labelled <- FALSE
 tidy.codes <- TRUE
 
-bm <- bench::mark(
-  "new" = comorbidity(x = x, id = id, code = code, map = map, assign0 = assign0, labelled = labelled, tidy.codes = tidy.codes, new = TRUE),
-  "old" = comorbidity(x = x, id = id, code = code, map = map, assign0 = assign0, labelled = labelled, tidy.codes = tidy.codes, new = FALSE),
-  iterations = 30
-)
-bm
-autoplot(bm)
+profvis::profvis({
+  comorbidity(x = x, id = id, code = code, map = map, assign0 = assign0, labelled = labelled, tidy.codes = tidy.codes)
+})


### PR DESCRIPTION
This implementation seems to be ~2x faster after some quick testing:

``` r
library(comorbidity)
library(bench)
library(ggplot2)
library(ggbeeswarm)
library(tidyr)

set.seed(1)
x <- data.frame(
  id = sample(seq(1e3), size = 1e5, replace = TRUE),
  code = sample_diag(1e5),
  stringsAsFactors = FALSE
)

addd <- sample(x = seq(nrow(x)), size = 5e3)
x$code[addd] <- paste0(".", x$code[addd])

bm <- bench::mark(
  "current" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, stringi = FALSE),
  "stringi" = comorbidity(x = x, id = "id", code = "code", map = "charlson_icd10_quan", assign0 = FALSE, stringi = TRUE),
  iterations = 30
)
bm
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 current       351ms    373ms      2.67    39.4MB     20.0
#> 2 stringi       177ms    177ms      5.64    33.6MB    197.
```

<sup>Created on 2021-07-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>